### PR TITLE
[Feat] CollctionViewCell 내용 추가, CartItem 구조 생성

### DIFF
--- a/kioskProject.xcodeproj/project.pbxproj
+++ b/kioskProject.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		E732364B2C342107004B0961 /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E732364A2C342107004B0961 /* MenuItem.swift */; };
 		E7B778F62C34DC0E00F75C89 /* MenuDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B778F52C34DC0E00F75C89 /* MenuDecoder.swift */; };
 		E7B778F92C34E44D00F75C89 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E7B778F82C34E44D00F75C89 /* SnapKit */; };
+		E7B7791B2C3674E100F75C89 /* CartItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B7791A2C3674E100F75C89 /* CartItem.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,7 @@
 		E73236482C3420F0004B0961 /* SegmentedBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedBar.swift; sourceTree = "<group>"; };
 		E732364A2C342107004B0961 /* MenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
 		E7B778F52C34DC0E00F75C89 /* MenuDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuDecoder.swift; sourceTree = "<group>"; };
+		E7B7791A2C3674E100F75C89 /* CartItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartItem.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +92,7 @@
 				E732364A2C342107004B0961 /* MenuItem.swift */,
 				E7B778F52C34DC0E00F75C89 /* MenuDecoder.swift */,
 				E73236432C342061004B0961 /* Menu.json */,
+				E7B7791A2C3674E100F75C89 /* CartItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -193,6 +196,7 @@
 			files = (
 				E73236422C34203D004B0961 /* CartCollectionViewCell.swift in Sources */,
 				E732363E2C342028004B0961 /* CartTableView.swift in Sources */,
+				E7B7791B2C3674E100F75C89 /* CartItem.swift in Sources */,
 				E73236402C342033004B0961 /* MenuCollectionViewCell.swift in Sources */,
 				E732363C2C34201E004B0961 /* MenuCollectionView.swift in Sources */,
 				E73236362C339F12004B0961 /* MainViewController.swift in Sources */,

--- a/kioskProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/kioskProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "4cdad746817ac9ed37e44dbe90a2ff25fc018954899b7d513e41a4bfc70f065a",
+  "pins" : [
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
+        "version" : "5.7.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/kioskProject.xcodeproj/xcuserdata/kseunghui.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/kioskProject.xcodeproj/xcuserdata/kseunghui.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "96612450-5FBA-4A42-AA34-CF3D1A185620"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/kioskProject.xcodeproj/xcuserdata/kseunghui.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/kioskProject.xcodeproj/xcuserdata/kseunghui.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -28,7 +28,7 @@
 		<key>kioskProject.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/kioskProject/Models/CartItem.swift
+++ b/kioskProject/Models/CartItem.swift
@@ -1,0 +1,15 @@
+//
+//  CartItem.swift
+//  kioskProject
+//
+//  Created by 김승희 on 7/4/24.
+//
+
+import Foundation
+
+struct CartItem {
+    let name: String
+    let price: String
+}
+
+var cartItems: [CartItem] = []

--- a/kioskProject/Models/MenuDecoder.swift
+++ b/kioskProject/Models/MenuDecoder.swift
@@ -26,12 +26,3 @@ func decodeMenuItems(from data: Data) -> [MenuItem]? {
         return nil
     }
 }
-
-// MenuItems 배열을 전역적으로 사용할 수 있도록 선언
-// menuItems 변수를 언래핑하여 사용
-let menuItems: [MenuItem]? = {
-    if let data = loadJsonData(filename: "Menu") {
-        return decodeMenuItems(from: data)
-    }
-    return nil
-}()

--- a/kioskProject/Models/MenuItem.swift
+++ b/kioskProject/Models/MenuItem.swift
@@ -13,3 +13,10 @@ struct MenuItem: Codable {
     var image: String
     var category: String
 }
+
+let menuItems: [MenuItem]? = {
+    if let data = loadJsonData(filename: "Menu") {
+        return decodeMenuItems(from: data)
+    }
+    return nil
+}()

--- a/kioskProject/Views/CartCollectionViewCell.swift
+++ b/kioskProject/Views/CartCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  CartCollectionViewCell.swift
+//  CartTableViewCell.swift
 //  kioskProject
 //
 //  Created by 김승희 on 7/2/24.
@@ -10,6 +10,6 @@
 import UIKit
 import SnapKit
 
-class CartCollectionViewCell: UICollectionViewCell {
+class CartTableViewCell: UITableViewCell {
     
 }

--- a/kioskProject/Views/MenuCollectionViewCell.swift
+++ b/kioskProject/Views/MenuCollectionViewCell.swift
@@ -11,5 +11,73 @@ import UIKit
 import SnapKit
 
 class MenuCollectionViewCell: UICollectionViewCell {
+    let menuImageView = UIImageView()
+    let menuNameLabel = UILabel()
+    let menuPriceLabel = UILabel()
+    let stackView = UIStackView()
     
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+        setupStackViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupViews() {
+        menuImageView.contentMode = .scaleAspectFill
+        menuNameLabel.font = .boldSystemFont(ofSize: 18)
+        menuPriceLabel.font = .systemFont(ofSize: 16)
+        
+        menuImageView.snp.makeConstraints {
+            $0.width.height.equalTo(100)
+        }
+    }
+    
+    func setupStackViews() {
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 10
+        
+        stackView.addArrangedSubview(menuImageView)
+        stackView.addArrangedSubview(menuNameLabel)
+        stackView.addArrangedSubview(menuPriceLabel)
+        
+        contentView.addSubview(stackView)
+        
+        stackView.snp.makeConstraints {
+            $0.centerX.equalTo(contentView)
+            $0.centerY.equalTo(contentView)
+            
+        }
+    }
+    
+    func configure(menuName: String, price: String, image: String){
+        menuNameLabel.text = menuName
+        loadImage(from: image)
+        menuPriceLabel.text = price
+    }
+    
+    private func loadImage(from urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                print("Failed to load image: \(error.localizedDescription)")
+                return
+            }
+            
+            guard let data = data, let image = UIImage(data: data) else {
+                print("Failed to decode image data")
+                return
+            }
+            
+            DispatchQueue.main.async {
+                self.menuImageView.image = image
+            }
+        }.resume()
+    }
 }


### PR DESCRIPTION
## 구현사항
- MenuCollcetionViewCell 코드 생성
- Image 링크를 이미지로 변환하는 코드 적용

## 특이사항
- Cart에는 menu, price 두 개만 들어가면 되기 때문에 기존 MenuItem 구조를 쓸 수 없다고 판단, CartItem을 새로 만들고 `var cartItems: [CartItem] = []` 으로 카트 Array를 전역변수로 설정했습니다.
- MenuCollectionView에서 [MenuItem] 으로 데이터 접근하면 화면에서 잘 보입니다.

## 앞으로 개선 사항
- 코드를 모두 합친 후 제약조건을 개선해야 할 것 같습니다.

## 스크린샷(선택)

![Simulator Screen Recording - iPhone 15 Pro - 2024-07-04 at 15 10 44](https://github.com/palrang22/kioskProject/assets/92323612/8c50335c-f42c-4fd8-be83-990dd10886dd)
